### PR TITLE
Ensure metadata.properties entry exists for fastg

### DIFF
--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -614,6 +614,8 @@ class Fastg(Sequence):
                         break
                 if line.startswith('#FASTG'):
                     props = {x.split('=')[0][1:]: x.split('=')[1] for x in re.findall(':[a-zA-Z0-9_]+=[a-zA-Z0-9_().,\" ]+', line)}
+                    if not dataset.metadata.properties:
+                        dataset.metadata.properties = {}
                     dataset.metadata.properties.update(props)
                     if 'version' in props:
                         dataset.metadata.version = props['version']


### PR DESCRIPTION
Ensure metadata.properties entry exists for fastg, which I think is an error we'd just worked around up until this point.  I need to dig deeper to make sure I understand what exactly was happening with exception handling for fastg, but I believe this fixes your branch.